### PR TITLE
Querying only for last review on reviews command and verifying only dismissed and pending status

### DIFF
--- a/scripts/lib/gh-parser.coffee
+++ b/scripts/lib/gh-parser.coffee
@@ -17,7 +17,7 @@ ghParser =
           prReviews.review = { state: "PENDING" } if reviewRequest["reviewer"]["login"] == login
         for review in pr["reviews"]["nodes"]
           prReviews.review = { state: review["state"], createdAt: review["createdAt"] }
-        reviews.push prReviews if prReviews.review.state
+        reviews.push prReviews if prReviews.review.state in ["DISMISSED", "PENDING"]
     reviews
 
   pullRequest: (pr) ->

--- a/scripts/lib/gh-query.coffee
+++ b/scripts/lib/gh-query.coffee
@@ -72,7 +72,7 @@ ghQuery =
                 nodes {
                   title
                   url
-                  reviews(last:50, author:$login, states:[DISMISSED,PENDING]) {
+                  reviews(last:1, author:$login, states:[DISMISSED,PENDING,APPROVED,CHANGES_REQUESTED]) {
                     nodes {
                       createdAt
                       state

--- a/tests/fixtures/review-response.json
+++ b/tests/fixtures/review-response.json
@@ -10,7 +10,15 @@
                   "title": "PR to review 1",
                   "url": "https:\/\/github.com\/test-org\/test-repo\/pull\/100",
                   "reviews": {
-                    "nodes": []
+                    "nodes": [
+                      {
+                        "createdAt": "2017-10-20T12:00:00Z",
+                        "state": "CHANGES_REQUESTED",
+                        "author": {
+                          "login": "test-reviewer-1"
+                        }
+                      }
+                    ]
                   },
                   "reviewRequests": {
                     "nodes": [
@@ -26,7 +34,15 @@
                   "title": "PR to review 2",
                   "url": "https:\/\/github.com\/test-org\/test-repo\/pull\/200",
                   "reviews": {
-                    "nodes": []
+                    "nodes": [
+                      {
+                        "createdAt": "2017-10-20T12:00:00Z",
+                        "state": "APPROVED",
+                        "author": {
+                          "login": "test-reviewer-1"
+                        }
+                      }
+                    ]
                   },
                   "reviewRequests": {
                     "nodes": []
@@ -58,13 +74,6 @@
                   "url": "https:\/\/github.com\/test-org\/test-repo\/pull\/400",
                   "reviews": {
                     "nodes": [
-                      {
-                        "createdAt": "2017-10-20T12:00:00Z",
-                        "state": "APPROVED",
-                        "author": {
-                          "login": "test-reviewer-1"
-                        }
-                      },
                       {
                         "createdAt": "2017-10-20T12:00:00Z",
                         "state": "DISMISSED",


### PR DESCRIPTION
Fixed bug where it would show reviews that were already approved. Now we just query for the last review and check if it is dismissed or pending