### PR TITLE
Using user id instead of name to send messages on hook requests

### DIFF
--- a/scripts/github.coffee
+++ b/scripts/github.coffee
@@ -57,13 +57,13 @@ module.exports = (robot) ->
 
   robot.respond /set user:(.*)/, (res) ->
     login = res.match[1]
-    setGithubUser(login, res.message.user.name)
+    setGithubUser(login, res.message.user.id)
     res.send "Got it! You are #{login} on GitHub."
 
   robot.router.post "/hubot/gh", (req, res) ->
     data = ghHookParser.parseHookRequest(req)
     if data
-      user = getGithubUser(data.user)
+      userId = getGithubUser(data.user)
       text = hookSummary.summary(data)
-      robot.messageRoom("@#{user}", text) if text? && user?
+      robot.messageRoom("#{userId}", text) if text? && userId?
     res.send "OK"

--- a/scripts/lib/gh-hook-parser.coffee
+++ b/scripts/lib/gh-hook-parser.coffee
@@ -11,7 +11,10 @@ ghHookParser =
     github_signature = request.headers["x-hub-signature"]
     payload = JSON.stringify(request.body)
     sig = "sha1=" + crypto.createHmac("sha1", GITHUB_WEBHOOK_SECRET).update(payload).digest("hex")
-    github_signature is sig
+    if github_signature is sig
+      true
+    else
+      throw "Invalid signature: #{github_signature} / #{sig}"
 
   status: (data) ->
     {

--- a/tests/github-test.coffee
+++ b/tests/github-test.coffee
@@ -179,4 +179,7 @@ describe "github script", ->
         # There's already 2 messages in room when setting the user
         expect(room.messages.length).to.equal(2)
 
+      it "responds with error", ->
+        expect(@response.statusCode).to.equal(500)
+
 


### PR DESCRIPTION
Using user id instead of name to send messages on hook requests. Also returning error in case signature is invalid. We have a bug that some ppl are not receiving messages. And the core-app project status updates also does not send messages properly, this is a tentative to fix those issues